### PR TITLE
UTF8 and fix newlines in CSV on windows

### DIFF
--- a/wwexport/__main__.py
+++ b/wwexport/__main__.py
@@ -15,6 +15,7 @@
 import core
 import queries
 import auth
+import constants
 
 import requests
 import sys
@@ -137,13 +138,13 @@ def main(argv):
         else:
             if args.type == SpaceType.spaces or args.type == SpaceType.all:
                 spaces = queries.team_spaces.all_pages(auth_token)
-                with open(export_root / "spaces.json", "w+") as f:
+                with open(export_root / "spaces.json", "w+", encoding=constants.FILE_ENCODING) as f:
                     json.dump(spaces, f)
                 spaces_to_export.extend(spaces)
 
             if args.type == SpaceType.dms or args.type == SpaceType.all:
                 dm_spaces = queries.dm_spaces.all_pages(auth_token)
-                with open(export_root / "dms.json", "w+") as f:
+                with open(export_root / "dms.json", "w+", encoding=constants.FILE_ENCODING) as f:
                     json.dump(dm_spaces, f)
                 spaces_to_export.extend(dm_spaces)
 

--- a/wwexport/__main__.py
+++ b/wwexport/__main__.py
@@ -27,7 +27,7 @@ import logging.handlers
 from enum import Enum
 from pathlib import Path
 
-export_root = Path.home() / "Watson Workspace Export"
+default_export_root = Path.home() / "Watson Workspace Export"
 debug_file_name = "debug.log"
 error_file_name = "errors.log"
 
@@ -56,8 +56,10 @@ class LogLevel(Enum):
 def main(argv):
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description="Export utility for Watson Workspace. This utility will create a directory at `{}` to export to.".format(export_root),
+        description="Export utility for Watson Workspace.",
         epilog="For example, to export spaces without files, run `python wwexport`. To export spaces with files, run `python wwexport --files=ALL`. To export all spaces and DMs with all files, run `python wwexport --type=ALL --files=ALL`. Always check the {} file in your export directory. Source at https://github.com/watsonwork/watsonworkspace-export".format(error_file_name))
+
+    parser.add_argument("--dir", default=default_export_root, help="Directory to export to. This directory will be created if it doesn't exist.")
 
     auth_group = parser.add_mutually_exclusive_group()
 
@@ -83,6 +85,7 @@ def main(argv):
 
     args = parser.parse_args()
 
+    export_root = Path(args.dir)
     export_root.mkdir(exist_ok=True, parents=True)
 
     logger = logging.getLogger("wwexport")

--- a/wwexport/constants.py
+++ b/wwexport/constants.py
@@ -14,6 +14,9 @@
 
 import datetime
 
+REQUEST_ENCODING = "UTF-8"
+FILE_ENCODING = "UTF-8"
+
 MESSAGES_FILE_NAME_PATTERN = "messages {}.csv"
 FILES_META_FOLDER = "_meta"
 FILE_ENTRIES_FILE_NAME = "entries.json"

--- a/wwexport/core.py
+++ b/wwexport/core.py
@@ -43,7 +43,7 @@ ResumePoint = namedtuple('ResumePoint', ['last_time', 'last_id'])
 
 
 def export_space_members(space_id: str, filename: str, auth_token: auth.AuthToken) -> list:
-    with open(filename, "w+") as space_members_file:
+    with open(filename, "w+", newline='', encoding=constants.FILE_ENCODING) as space_members_file:
         space_members_writer = csv.writer(space_members_file)
         space_members = []
         after = None
@@ -87,12 +87,12 @@ def export_space_files(space_id: str, folder: PurePath, auth_token: str, fetch_a
     file_graphqlitem_by_id = {}
     file_entries_file_path = folder / constants.FILES_META_FOLDER / constants.FILE_ENTRIES_FILE_NAME
     if (file_entries_file_path).exists():
-        with open(file_entries_file_path, "r") as f:
+        with open(file_entries_file_path, "r", encoding=constants.FILE_ENCODING) as f:
             file_graphqlitem_by_id = json.load(f)
     file_path_by_id = {}
     file_paths_file_path = folder / constants.FILES_META_FOLDER / constants.FILE_PATHS_FILE_NAME
     if (file_paths_file_path).exists():
-        with open(file_paths_file_path, "r") as f:
+        with open(file_paths_file_path, "r", encoding=constants.FILE_ENCODING) as f:
             file_path_by_id = json.load(f)
 
     downloaded = 0
@@ -160,11 +160,11 @@ def export_space_files(space_id: str, folder: PurePath, auth_token: str, fetch_a
         # if we have some metadata, write it
         if len(file_graphqlitem_by_id) > 0:
             file_entries_file_path.parent.mkdir(exist_ok=True, parents=True)
-            with open(file_entries_file_path, "w+") as f:
+            with open(file_entries_file_path, "w+", encoding=constants.FILE_ENCODING) as f:
                 json.dump(file_graphqlitem_by_id, f)
         if len(file_path_by_id) > 0:
             file_paths_file_path.parent.mkdir(exist_ok=True, parents=True)
-            with open(file_paths_file_path, "w+") as f:
+            with open(file_paths_file_path, "w+", encoding=constants.FILE_ENCODING) as f:
                 json.dump(file_path_by_id, f)
 
     logger.info("Downloaded %s files, %s files were skipped because they were downloaded according to meta files, %s downloaded files were duplicates of files already downloaded",
@@ -211,7 +211,7 @@ def find_messages_resume_point(space_export_root) -> ResumePoint:
             path = get_messages_path(space_export_root, year, month)
             if path.exists():
                 logger.debug("Found possible resume point in %s", path)
-                with open(path, "r") as space_messages_file:
+                with open(path, "r", newline='', encoding=constants.FILE_ENCODING) as space_messages_file:
                     space_messages_reader = csv.reader(space_messages_file)
                     last_message_time = None
                     for line in space_messages_reader:
@@ -366,7 +366,7 @@ def export_space(space: dict, auth_token: str, export_root_folder: PurePath, fil
                             exist_ok=True, parents=True)
 
                         resuming_file = new_messages_path.exists()
-                        space_messages_file = open(new_messages_path, "a")
+                        space_messages_file = open(new_messages_path, "a", newline='', encoding=constants.FILE_ENCODING)
                         current_messages_path = new_messages_path
 
                         space_messages_writer = csv.writer(space_messages_file)

--- a/wwexport/queries.py
+++ b/wwexport/queries.py
@@ -105,7 +105,9 @@ class Query:
             logger.debug("POST %s\n%s\n%s", constants.GRAPHQL_URL, request, params)
         else:
             logger.debug("POST %s\n%s", constants.GRAPHQL_URL, request)
-        response = requests.post(constants.GRAPHQL_URL, data=request, params=params,
+        response = requests.post(constants.GRAPHQL_URL,
+                                 data=request.encode(constants.REQUEST_ENCODING),
+                                 params=params,
                                  headers=self.__graphql_headers(auth_token))
         if response.status_code == 401:
             raise UnauthorizedRequestError()


### PR DESCRIPTION
See footnote in https://docs.python.org/3.3/library/csv.html#id3 - need `newline=''` when opening a file for use with CSV libraries, especially on Windows. Adding explicit UTF 8 which will help on some environments.