### PR TITLE
change to absolute imports for bundling tool compatibility

### DIFF
--- a/wwexport/__main__.py
+++ b/wwexport/__main__.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import core
-import queries
-import auth
-import constants
+from wwexport import core
+from wwexport import queries
+from wwexport import auth
+from wwexport import constants
 
 import requests
 import sys

--- a/wwexport/auth.py
+++ b/wwexport/auth.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import constants
+from wwexport import constants
 
 import sys
 import requests

--- a/wwexport/core.py
+++ b/wwexport/core.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import queries
-import auth
+from wwexport import queries
+from wwexport import auth
+from wwexport import constants
 
-import constants
 import logging
 import csv
 import datetime

--- a/wwexport/queries.py
+++ b/wwexport/queries.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import constants
-import auth
+from wwexport import constants
+from wwexport import auth
 
 import datetime
 import requests


### PR DESCRIPTION
Relative imports cause problems with some of the bundling tools we are looking at