### PR TITLE
Simplify markup and remove unnecessary styles

### DIFF
--- a/wwexport/resources/styles.css
+++ b/wwexport/resources/styles.css
@@ -1,14 +1,12 @@
-.ww-export-header {
+body {
   font-family: Helvetica Neue for IBM, Helvetica Neue, Helvetica, Arial, Roboto;
+}
+
+.ww-export-header {
   font-size: 12px;
 }
 
 .ic-person {
-  box-sizing: border-box;
-  color: rgb(29, 54, 73);
-  cursor: pointer;
-  display: inline-block;
-  font-family: Helvetica Neue for IBM, Helvetica Neue, Helvetica, Arial, Roboto;
   font-size: 12px;
   font-weight: 500;
   line-height: 18.2px;
@@ -16,46 +14,28 @@
 }
 
 .ic-timestamp {
-  box-sizing: border-box;
   color: rgb(119, 118, 119);
-  display: inline-block;
-  font-family: Helvetica Neue for IBM, Helvetica Neue, Helvetica, Arial, Roboto;
   font-size: 12px;
   font-weight: 300;
   line-height: 15.6px;
 }
 
 .ic-message-container {
-  box-sizing: border-box;
-  color: rgb(29, 54, 73);
-  font-family: Helvetica Neue for IBM, Helvetica Neue, Helvetica, Arial, Roboto;
   font-weight: 200;
-  line-height: 24px;
 }
 
 .ic-transcript-item {
-  box-sizing: border-box;
   color: rgb(29, 54, 73);
-  direction: ltr;
-  display: flex;
-  flex-direction: column;
-  font-family: Helvetica Neue for IBM, Helvetica Neue, Helvetica, Arial, Roboto;
   line-height: 24px;
-  list-style-type: none;
   padding-left: 10px;
   padding-right: 10px;
 }
 
 .ic-message-date {
-  align-self: flex-start;
-  box-sizing: border-box;
   color: rgb(119, 118, 119);
-  font-family: Helvetica Neue for IBM, Helvetica Neue, Helvetica, Arial, Roboto;
   font-size: 16px;
   font-weight: 400;
   line-height: 21px;
-  list-style-type: none;
   padding-bottom: 15px;
-  padding-right: 20px;
   padding-top: 15px;
 }

--- a/wwexport/templates/messages.html
+++ b/wwexport/templates/messages.html
@@ -28,31 +28,15 @@
       <hr/>
       {% endif %}
       <div class="ic-transcript-item">
-        <div id="{{ message["message id"] }}" class="ic-message">
-          <div class="ic-avatar-message">
-            <div class="ic-message-data">
-              <div class="ic-message-meta">
-                <div tabindex="0" class="ic-person ic-person-with-card">{{ message["author name"]|name_case }}</div>
-                <span title="{{ ns.message_created|format_datetime }}" class="ic-timestamp">{{ ns.message_created|format_datetime }}</span>
-              </div>
-              <div class="ic-general-annotation ic-single-message-rendering">
-                <div class="ic-annotation-border" style="display: none;"></div>
-                <div class="ic-annotation-content">
-                  <div class="ic-message-text">
-                    <div class="ic-markdown-para">
-                      <span class="ic-markdown-para-content">
-                        <span class="ic-markdown-content-wrapper">
-                          <span class="ic-message-container">
-                            <span>{{ message["content"] | md | safe }}</span>
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+        <div class="ic-message-meta">
+          <span class="ic-person">{{ message["author name"]|name_case }}</span>
+          <span class="ic-timestamp">{{ ns.message_created|format_datetime }}</span>
+        </div>
+        <div>
+          <div class="ic-annotation-border" style="display: none;"></div>
+          <span class="ic-message-container">
+            {{ message["content"] | md | safe }}
+          </span>
         </div>
       </div>
     {% set ns.last_message_created_date = ns.message_created.date() %}


### PR DESCRIPTION
- Remove wrapper elements that don't serve any purpose in the static output
- Remove duplicate / unnecessary styles