### PR TITLE
Remove requests module - replace with standard python urllib

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,6 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-requests = "*"
 python-dateutil = "*"
 pandas = "*"
 "jinja2" = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -4,13 +4,26 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-python-dateutil = "*"
-pandas = "*"
-"jinja2" = "*"
-babel = "*"
-mistletoe = "*"
-tqdm = "*"
-bleach = "*"
+python-dateutil = "==2.7.5"
+pandas = "==0.23.4"
+mistletoe = "==0.7.1"
+tqdm = "==4.29.0"
+bleach = "==3.0.2"
+altgraph = "==0.16.1"
+certifi = "==2018.11.29"
+future = "==0.17.1"
+idna = "==2.8"
+macholib = "==1.11"
+numpy = "==1.15.4"
+pefile = "==2018.8.8"
+pytz = "==2018.7"
+six = "==1.12.0"
+"urllib3" = "==1.24.1"
+webencodings = "==0.5.1"
+"Jinja2" = "==2.10"
+Babel = "==2.6.0"
+MarkupSafe = "==1.1.0"
+PyInstaller = "==3.4"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2bda85a53436a4e934a960929a3545a1b226256cb19b0e462dac364f4c97eff5"
+            "sha256": "e21dcdd8fc05051b4d1543710fd9b15b88a8fb95ef66a6fe7d8b67b33e55b128"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,32 +26,11 @@
         },
         "bleach": {
             "hashes": [
-                "sha256:48d39675b80a75f6d1c3bdbffec791cf0bbbab665cf01e20da701c77de278718",
-                "sha256:73d26f018af5d5adcdabf5c1c974add4361a9c76af215fe32fdec8a6fc5fb9b9"
+                "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
+                "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"
             ],
             "index": "pypi",
-            "version": "==3.0.2"
-        },
-        "certifi": {
-            "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
-            ],
-            "version": "==2018.11.29"
-        },
-        "chardet": {
-            "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
-            ],
-            "version": "==3.0.4"
-        },
-        "idna": {
-            "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
-            ],
-            "version": "==2.8"
+            "version": "==3.1.0"
         },
         "jinja2": {
             "hashes": [
@@ -170,18 +149,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
-                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
+                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
             ],
-            "version": "==2018.7"
-        },
-        "requests": {
-            "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
-            ],
-            "index": "pypi",
-            "version": "==2.21.0"
+            "version": "==2018.9"
         },
         "six": {
             "hashes": [
@@ -192,18 +163,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:3c4d4a5a41ef162dd61f1edb86b0e1c7859054ab656b2e7c7b77e7fbf6d9f392",
-                "sha256:5b4d5549984503050883bc126280b386f5f4ca87e6c023c5d015655ad75bdebb"
+                "sha256:79420109a762f82e20e8ecdc3b3bc1bc6c6536884a8de5fa86a50eb99386376a",
+                "sha256:7fa801cf60e318bf7d2ac7498254df0f3d7a3ad23c622ae63666257d5f833967"
             ],
             "index": "pypi",
-            "version": "==4.28.1"
-        },
-        "urllib3": {
-            "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
-            ],
-            "version": "==1.24.1"
+            "version": "==4.29.0"
         },
         "webencodings": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e21dcdd8fc05051b4d1543710fd9b15b88a8fb95ef66a6fe7d8b67b33e55b128"
+            "sha256": "f492b6c8b204b5dbbca195246c2fef6b47cd4b60f5f43fadfde493d89602b461"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "altgraph": {
+            "hashes": [
+                "sha256:d6814989f242b2b43025cba7161fc1b8fb487a62cd49c49245d6fd01c18ac997",
+                "sha256:ddf5320017147ba7b810198e0b6619bd7b5563aa034da388cea8546b877f9b0c"
+            ],
+            "index": "pypi",
+            "version": "==0.16.1"
+        },
         "babel": {
             "hashes": [
                 "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
@@ -26,11 +34,34 @@
         },
         "bleach": {
             "hashes": [
-                "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
-                "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"
+                "sha256:48d39675b80a75f6d1c3bdbffec791cf0bbbab665cf01e20da701c77de278718",
+                "sha256:73d26f018af5d5adcdabf5c1c974add4361a9c76af215fe32fdec8a6fc5fb9b9"
             ],
             "index": "pypi",
-            "version": "==3.1.0"
+            "version": "==3.0.2"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+            ],
+            "index": "pypi",
+            "version": "==2018.11.29"
+        },
+        "future": {
+            "hashes": [
+                "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
+            ],
+            "index": "pypi",
+            "version": "==0.17.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "index": "pypi",
+            "version": "==2.8"
         },
         "jinja2": {
             "hashes": [
@@ -39,6 +70,14 @@
             ],
             "index": "pypi",
             "version": "==2.10"
+        },
+        "macholib": {
+            "hashes": [
+                "sha256:ac02d29898cf66f27510d8f39e9112ae00590adb4a48ec57b25028d6962b1ae1",
+                "sha256:c4180ffc6f909bf8db6cd81cff4b6f601d575568f4d5dee148c830e9851eb9db"
+            ],
+            "index": "pypi",
+            "version": "==1.11"
         },
         "markupsafe": {
             "hashes": [
@@ -71,6 +110,7 @@
                 "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
                 "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
             ],
+            "index": "pypi",
             "version": "==1.1.0"
         },
         "mistletoe": {
@@ -111,6 +151,7 @@
                 "sha256:ecf81720934a0e18526177e645cbd6a8a21bb0ddc887ff9738de07a1df5c6b61",
                 "sha256:edfa6fba9157e0e3be0f40168eb142511012683ac3dc82420bee4a3f3981b30e"
             ],
+            "index": "pypi",
             "version": "==1.15.4"
         },
         "pandas": {
@@ -139,6 +180,20 @@
             "index": "pypi",
             "version": "==0.23.4"
         },
+        "pefile": {
+            "hashes": [
+                "sha256:4c5b7e2de0c8cb6c504592167acf83115cbbde01fe4a507c16a1422850e86cd6"
+            ],
+            "index": "pypi",
+            "version": "==2018.8.8"
+        },
+        "pyinstaller": {
+            "hashes": [
+                "sha256:a5a6e04a66abfcf8761e89a2ebad937919c6be33a7b8963e1a961b55cb35986b"
+            ],
+            "index": "pypi",
+            "version": "==3.4"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
@@ -149,16 +204,18 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
             ],
-            "version": "==2018.9"
+            "index": "pypi",
+            "version": "==2018.7"
         },
         "six": {
             "hashes": [
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
+            "index": "pypi",
             "version": "==1.12.0"
         },
         "tqdm": {
@@ -169,11 +226,20 @@
             "index": "pypi",
             "version": "==4.29.0"
         },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "index": "pypi",
+            "version": "==1.24.1"
+        },
         "webencodings": {
             "hashes": [
                 "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
                 "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
             ],
+            "index": "pypi",
             "version": "==0.5.1"
         }
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ PyInstaller==3.4
 python-dateutil==2.7.5
 pytz==2018.7
 six==1.12.0
-tqdm==4.28.1
+tqdm==4.29.0
 urllib3==1.24.1
 webencodings==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ altgraph==0.16.1
 Babel==2.6.0
 bleach==3.0.2
 certifi==2018.11.29
-chardet==3.0.4
 future==0.17.1
 idna==2.8
 Jinja2==2.10
@@ -15,7 +14,6 @@ pefile==2018.8.8
 PyInstaller==3.4
 python-dateutil==2.7.5
 pytz==2018.7
-requests==2.21.0
 six==1.12.0
 tqdm==4.28.1
 urllib3==1.24.1

--- a/wwexport/__main__.py
+++ b/wwexport/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2018 IBM
+# Copyright 2018-2019 IBM
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ from wwexport import ww_html
 import hashlib
 import shutil
 import fnmatch
-import requests
+import urllib
 import sys
 import argparse
 import getpass
@@ -187,8 +187,8 @@ def main(argv):
     except queries.GraphQLError:
         logger.exception("Export incomplete. Terminating with GraphQLError. If problem persists, run with a debug enabled and check the prior request. You may also run the export space by space.")
         error = True
-    except requests.exceptions.ConnectionError:
-        logger.exception("Export incomplete. Connection was interrupted. Restart the export and it will resume where you left off (for the most part)")
+    except urllib.error.URLError:
+        logger.exception("Export incomplete. Problem with the HTTP Connection. Restart the export and it will resume where you left off (for the most part).")
         error = True
     except auth.UnauthorizedRequestError:
         logger.exception("Export incomplete. Unable to authenticate or reauthenticate.")

--- a/wwexport/__main__.py
+++ b/wwexport/__main__.py
@@ -178,11 +178,11 @@ def main(argv):
 
     except queries.UnauthorizedRequestError:
         msg = "Export incomplete. Looks like your JWT might have timed out or is invalid. Good thing this is resumable. Go get a new one and run this again. We'll pick up from where we left off (more or less)."
-        tqdm.write(msg)
+        print(msg)
         logger.error(msg)
     except queries.UnknownRequestError as err:
         logger.exception(
-            "Export incomplete. Aborting with HTTP status code %s. If problem persists, run with a debug enabled and check the prior request. You may also run the export space by space.", err.status_code)
+            "Export incomplete. Aborting with HTTP status code %s and reason %s. If problem persists, run with a debug enabled and check the prior request. You may also run the export space by space.", err.status_code, err.reason)
         error = True
     except queries.GraphQLError:
         logger.exception("Export incomplete. Terminating with GraphQLError. If problem persists, run with a debug enabled and check the prior request. You may also run the export space by space.")
@@ -198,10 +198,14 @@ def main(argv):
         error = True
 
     if error:
-        tqdm.write("An error prevented some part of the export. Check the {} and {} files in your export directory for more information.".format(debug_file_name, error_file_name))
+        msg = "An error prevented some part of the export. Check the {} and {} files in your export directory for more information.".format(debug_file_name, error_file_name)
+        logger.critical(msg)
+        print(msg)
         sys.exit(1)
     else:
-        logger.info("Completed export")
+        msg = "Completed export"
+        logger.info(msg)
+        print(msg)
         sys.exit(0)
 
 

--- a/wwexport/__main__.py
+++ b/wwexport/__main__.py
@@ -182,7 +182,7 @@ def main(argv):
         logger.error(msg)
     except queries.UnknownRequestError as err:
         logger.exception(
-            "Export incomplete. Aborting with HTTP status code %s with response %s. If problem persists, run with a debug enabled and check the prior request. You may also run the export space by space.", err.status_code, err.text)
+            "Export incomplete. Aborting with HTTP status code %s. If problem persists, run with a debug enabled and check the prior request. You may also run the export space by space.", err.status_code)
         error = True
     except queries.GraphQLError:
         logger.exception("Export incomplete. Terminating with GraphQLError. If problem persists, run with a debug enabled and check the prior request. You may also run the export space by space.")

--- a/wwexport/auth.py
+++ b/wwexport/auth.py
@@ -82,16 +82,17 @@ class AppAuthToken(AuthToken):
 
         request = urllib.Request(constants.OAUTH_URL, data=data, headers=constants.OAUTH_REQUEST_HEADERS)
 
-        with urllib.request.urlopen(request) as response:
-            if response.getcode() != 200:
-                logger.critical("Tried to authenticate an app, got error code %s with response %s", response.status_code, response.json())
-                raise UnauthorizedRequestError()
-            self.full_response = json.loads(response.read())
-            self.jwt = self.full_response["access_token"]
-            self.expires_in_secs = datetime.timedelta(seconds=self.full_response["expires_in"])
-            self.expiry_time = self.request_time + self.expires_in_secs - constants.JWT_TOKEN_REFRESH_BUFFER
-            logger.log(5, "refreshed auth token at %s - token will expire in %s, with a buffer next refresh will be at %s", self.request_time, self.expires_in_secs, self.expiry_time)
-            return self.full_response
+        try:
+            with urllib.request.urlopen(request) as response:
+                self.full_response = json.loads(response.read())
+                self.jwt = self.full_response["access_token"]
+                self.expires_in_secs = datetime.timedelta(seconds=self.full_response["expires_in"])
+                self.expiry_time = self.request_time + self.expires_in_secs - constants.JWT_TOKEN_REFRESH_BUFFER
+                logger.log(5, "refreshed auth token at %s - token will expire in %s, with a buffer next refresh will be at %s", self.request_time, self.expires_in_secs, self.expiry_time)
+                return self.full_response
+        except urllib.error.HTTPError as err:
+            logger.critical("Tried to authenticate an app, got error code %s with reason %s", err.code, err.reason)
+            raise UnauthorizedRequestError()
 
     def jwt_token(self):
         refresh_needed = self.request_time is None or self.expires_in_secs is None or datetime.datetime.now() > self.expiry_time

--- a/wwexport/auth.py
+++ b/wwexport/auth.py
@@ -14,14 +14,13 @@
 
 from wwexport import constants
 
+import json
+import urllib
 import sys
-import requests
 import argparse
 import logging
 import datetime
 from abc import abstractmethod
-
-from requests.auth import HTTPBasicAuth
 
 logger = logging.getLogger("wwexport")
 
@@ -76,16 +75,23 @@ class AppAuthToken(AuthToken):
         logger.info("Getting access token for app")
         self.request_time = datetime.datetime.now()
         data = {'grant_type': 'client_credentials'}
-        response = requests.post(constants.OAUTH_URL, data=data, auth=HTTPBasicAuth(self.app_id, self.app_secret), headers=constants.OAUTH_REQUEST_HEADERS)
-        if response.status_code != 200:
-            logger.critical("Tried to authenticate an app, got error code %s with response %s", response.status_code, response.json())
-            raise UnauthorizedRequestError()
-        self.full_response = response.json()
-        self.jwt = self.full_response["access_token"]
-        self.expires_in_secs = datetime.timedelta(seconds=self.full_response["expires_in"])
-        self.expiry_time = self.request_time + self.expires_in_secs - constants.JWT_TOKEN_REFRESH_BUFFER
-        logger.log(5, "refreshed auth token at %s - token will expire in %s, with a buffer next refresh will be at %s", self.request_time, self.expires_in_secs, self.expiry_time)
-        return self.full_response
+
+        pw_manager = urllib.HTTPPasswordMgrWithDefaultRealm()
+        pw_manager.add_password(None, constants.OAUTH_URL, self.app_id, self.app_secret)
+        urllib.install_opener(urllib.build_opener(urllib.HTTPBasicAuthHandler(pw_manager)))
+
+        request = urllib.Request(constants.OAUTH_URL, data=data, headers=constants.OAUTH_REQUEST_HEADERS)
+
+        with urllib.request.urlopen(request) as response:
+            if response.getcode() != 200:
+                logger.critical("Tried to authenticate an app, got error code %s with response %s", response.status_code, response.json())
+                raise UnauthorizedRequestError()
+            self.full_response = json.loads(response.read())
+            self.jwt = self.full_response["access_token"]
+            self.expires_in_secs = datetime.timedelta(seconds=self.full_response["expires_in"])
+            self.expiry_time = self.request_time + self.expires_in_secs - constants.JWT_TOKEN_REFRESH_BUFFER
+            logger.log(5, "refreshed auth token at %s - token will expire in %s, with a buffer next refresh will be at %s", self.request_time, self.expires_in_secs, self.expiry_time)
+            return self.full_response
 
     def jwt_token(self):
         refresh_needed = self.request_time is None or self.expires_in_secs is None or datetime.datetime.now() > self.expiry_time

--- a/wwexport/auth.py
+++ b/wwexport/auth.py
@@ -1,4 +1,4 @@
-# Copyright 2018 IBM
+# Copyright 2018-2019 IBM
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/wwexport/queries.py
+++ b/wwexport/queries.py
@@ -39,9 +39,8 @@ class UnauthorizedRequestError(RequestError):
 class UnknownRequestError(RequestError):
     """Something else went wrong."""
 
-    def __init__(self, status_code, text):
-        self.status_code = status_code
-        self.text = text
+    def __init__(self, response):
+        self.status_code = response.getcode()
 
 
 class GraphQLError(RequestError):

--- a/wwexport/queries.py
+++ b/wwexport/queries.py
@@ -1,4 +1,4 @@
-# Copyright 2018 IBM
+# Copyright 2018-2019 IBM
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/wwexport/queries.py
+++ b/wwexport/queries.py
@@ -16,7 +16,7 @@ from wwexport import constants
 from wwexport import auth
 
 import datetime
-import requests
+import urllib
 import logging
 import json
 import time
@@ -39,9 +39,9 @@ class UnauthorizedRequestError(RequestError):
 class UnknownRequestError(RequestError):
     """Something else went wrong."""
 
-    def __init__(self, response: requests.Response):
-        self.status_code = response.status_code
-        self.text = response.text
+    def __init__(self, status_code, text):
+        self.status_code = status_code
+        self.text = text
 
 
 class GraphQLError(RequestError):
@@ -66,8 +66,8 @@ class Query:
         return {'jwt': auth_token.jwt_token(), 'Content-Type': 'application/graphql', 'x-graphql-view': self.graphql_views}
 
     @staticmethod
-    def __handle_json_response(response: requests.Response, reference_to_get: list):
-        next_level = response.json()
+    def __handle_json_response(response_json: str, reference_to_get: list):
+        next_level = response_json
         logger.log(5, "response JSON\n%s", next_level)
 
         if "errors" in next_level:
@@ -90,7 +90,7 @@ class Query:
                 return None
         return next_level
 
-    def __graphql_request(self, auth_token: auth.AuthToken, request: str, params: str = None) -> requests.Response:
+    def __graphql_request(self, auth_token: auth.AuthToken, graphql_request: str, params: str = None) -> str:
         now = datetime.datetime.now()
         if type(self).__last_graphql_request_time:
             elapsed = now - type(self).__last_graphql_request_time
@@ -102,26 +102,26 @@ class Query:
 
         type(self).__last_graphql_request_time = now
         if params:
-            logger.debug("POST %s\n%s\n%s", constants.GRAPHQL_URL, request, params)
+            url = constants.GRAPHQL_URL + "?" + urllib.parse.urlencode(params)
         else:
-            logger.debug("POST %s\n%s", constants.GRAPHQL_URL, request)
-        response = requests.post(constants.GRAPHQL_URL,
-                                 data=request.encode(constants.REQUEST_ENCODING),
-                                 params=params,
-                                 headers=self.__graphql_headers(auth_token))
-        if response.status_code == 401:
-            raise UnauthorizedRequestError()
-        elif response.status_code != 200:
-            raise UnknownRequestError(response)
-
-        return response
+            url = constants.GRAPHQL_URL
+        logger.debug("POST %s\n%s", url, graphql_request)
+        request = urllib.request.Request(url,
+                                         data=graphql_request.encode(constants.REQUEST_ENCODING),
+                                         headers=self.__graphql_headers(auth_token))
+        with urllib.request.urlopen(request) as response:
+            if response.getcode() == 401:
+                raise UnauthorizedRequestError()
+            elif response.getcode() != 200:
+                raise UnknownRequestError(response)
+            return json.loads(response.read())
 
     def execute(self, auth_token: auth.AuthToken, **kwargs: dict):
         params = {'variables': json.dumps(kwargs)} if kwargs is not None else {}
         logger.info("Executing query %s with params %s", self.name, params)
-        response = self.__graphql_request(
-            request=self.query_string, params=params, auth_token=auth_token)
-        return self.__handle_json_response(response, self.key_reference)
+        response_json = self.__graphql_request(
+            graphql_request=self.query_string, params=params, auth_token=auth_token)
+        return self.__handle_json_response(response_json, self.key_reference)
 
     def all_pages(self, auth_token: auth.AuthToken, **kwargs: dict):
         """Iterately calls execute with the provided query, using standard
@@ -144,36 +144,21 @@ def __download_headers(auth_token: auth.AuthToken) -> dict:
     return {'jwt': auth_token.jwt_token()}
 
 
-def download(file_id: str, file_title: str, folder: PurePath, auth_token: str):
-    logger.info("Downloading file %s with title %s", file_id, file_title)
-    download_url = constants.FILE_DOWNLOAD_URL_FORMAT.format(file_id)
-    logger.debug("file url %s", download_url)
-
-    logger.log(5, "waiting for %s seconds", constants.FILE_DOWNLOAD_WAIT)
-    time.sleep(constants.FILE_DOWNLOAD_WAIT)
-
-    response = requests.get(download_url, stream=True,
-                            headers=__download_headers(auth_token))
-    if response.status_code == 401:
-        raise UnauthorizedRequestError()
-    elif response.status_code == 204:
-        content_location = response.headers["x-content-location"]
-        response = requests.get(content_location, stream=True)
-    elif response.status_code != 200:
-        raise UnknownRequestError(response)
-
+def __handle_download(response, id: str, file_title: str, folder: PurePath):
     bytes_written = 0
     new_file = False
 
-    temp_file_path = folder / file_id
+    temp_file_path = folder / id
 
     try:
         # download to a temp file by using the id as the file name
         with open(temp_file_path, "wb") as local_file:
-            for chunk in response.iter_content(chunk_size=1024):
-                if chunk:
-                    local_file.write(chunk)
-                    bytes_written += len(chunk)
+            while True:
+                chunk = response.read(1024)
+                if not chunk:
+                    break
+                local_file.write(chunk)
+                bytes_written += len(chunk)
         logger.debug("wrote %s bytes", bytes_written)
 
         base_file_path = folder / file_title
@@ -200,12 +185,37 @@ def download(file_id: str, file_title: str, folder: PurePath, auth_token: str):
             new_file = True
             temp_file_path.rename(candidate_file_path)
             logger.debug("file %s with id %s saved as %s",
-                         file_title, file_id, candidate_file_path)
+                         file_title, id, candidate_file_path)
     finally:
         if temp_file_path.exists():
             temp_file_path.unlink()
 
     return candidate_file_path, new_file
+
+
+def download(file_id: str, file_title: str, folder: PurePath, auth_token: str):
+    logger.info("Downloading file %s with title %s", file_id, file_title)
+    download_url = constants.FILE_DOWNLOAD_URL_FORMAT.format(file_id)
+    logger.debug("file url %s", download_url)
+
+    logger.log(5, "waiting for %s seconds", constants.FILE_DOWNLOAD_WAIT)
+    time.sleep(constants.FILE_DOWNLOAD_WAIT)
+
+    request = urllib.request.Request(download_url,
+                                     headers=__download_headers(auth_token))
+    with urllib.request.urlopen(request) as response:
+        if response.getcode() == 401:
+            raise UnauthorizedRequestError()
+        elif response.getcode() == 204:
+            content_location = response.headers["x-content-location"]
+            redirected_request = urllib.request.Request(content_location,
+                                                        headers=__download_headers(auth_token))
+            with urllib.request.urlopen(redirected_request) as redirected_response:
+                return __handle_download(redirected_response, file_id, file_title, folder)
+        elif response.getcode() != 200:
+            raise UnknownRequestError(response)
+        else:
+            return __handle_download(response, file_id, file_title, folder)
 
 
 dm_spaces = Query("DM Spaces", """query getDMSpaces($after: String) {


### PR DESCRIPTION
Primary change here is to change from requests to urllib. This is to simplify by using more built-in modules. This is a fairly straightforward change, but there were two small structural changes required:
- the requests library returns a response with error codes whereas urllib will raise an error, so the code was adjusted for that as well.
- urllib also uses a context handler approach for closing connections (https://docs.python.org/2/library/contextlib.html). I refactored the download method a bit because of this since there are redirects and the code handles reading from either the initial response or a redirect

In making this change, I ran into some issues with tqdm similar to those documented here:
https://github.com/tqdm/tqdm/issues/613
I had noticed this before, and was planning to address, but they made it difficult to fully confirm the changes here so I addressed them in this PR.

To address that, I attempted to update the latest tqdm. There was an attempt to address this in tqdm, but after updating tqdm, I encountered another issue with tqdm that seems to also occur when using breaks inside tqdm loops. To resolve this, I abandoned using the tqdm libraries to write messages once we are in the final error handling phases, and directly interact with print. Directly interacting with print is a bad practice in the middle of tqdm usage since it overwrites tqdm's output, but since this comes at the end, after all usage of tqdm, it is OK, and avoids problems with tqdm that can happen after breaks.