### PR TITLE
Improve output sanitisation

### DIFF
--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -21,8 +21,10 @@ import sys
 import argparse
 import dateutil
 from pathlib import Path
+from functools import partial
 
-import bleach
+from bleach.sanitizer import Cleaner
+from bleach.linkifier import LinkifyFilter
 from mistletoe import Document, html_renderer
 from mistletoe.span_token import SpanToken
 import pandas as pd
@@ -31,8 +33,16 @@ from babel.dates import format_date, format_datetime, format_time
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 logger = logging.getLogger("wwexport")
-allowed_tags = ["p", "img"] + bleach.sanitizer.ALLOWED_TAGS
 
+cleaner = Cleaner(
+    tags=['a', 'code', 'em', 'img', 'p', 'pre', 'span', 'strong'],
+    attributes={'a': ['href', 'rel'], 'img': ['src']},
+    styles=[],
+    protocols=['file', 'ftp', 'ftps', 'git', 'http', 'https', 'ibmscp', 'ldap', 'ldaps', 'mailto', 'notes', 'tel', 'watsonworkspace'],
+    strip=False,
+    strip_comments=True,
+    filters=[partial(LinkifyFilter, skip_tags=['code', 'pre'])]
+)
 
 class WWMentionSpan(SpanToken):
     pattern = re.compile(r"\<\@(.+?)\|(.+?)\>")
@@ -49,6 +59,13 @@ class WWSpaceMentionSpan(SpanToken):
         self.parse_inner = False
         self.display = match.group(1)
 
+class WWFileSpan(SpanToken):
+    pattern = re.compile(r"\<\$file\|.+\|(.*)\>")
+
+    def __init__(self, match):
+        self.parse_inner = False
+        self.name = match.group(1)
+
 class WWImageSpan(SpanToken):
     pattern = re.compile(r"\<\$image\|(.*?)(\|(([0-9])+x([0-9])+))?\>")
 
@@ -56,7 +73,7 @@ class WWImageSpan(SpanToken):
         self.parse_inner = False
         self.id = match.group(1)
         self.size = match.group(3)
-        self.length = match.group(4)
+        self.width = match.group(4)
         self.height = match.group(5)
 
 class WWBoldSpan(SpanToken):
@@ -67,13 +84,16 @@ class WWBoldSpan(SpanToken):
 
 class WWHTMLRenderer(html_renderer.HTMLRenderer):
     def __init__(self):
-        super().__init__(WWMentionSpan, WWSpaceMentionSpan, WWImageSpan, WWBoldSpan)
+        super().__init__(WWMentionSpan, WWSpaceMentionSpan, WWFileSpan, WWImageSpan, WWBoldSpan)
 
     def render_ww_mention_span(self, token):
         return "<strong>{name}</strong>".format(name=token.display)
 
     def render_ww_space_mention_span(self, token):
         return self.render_ww_mention_span(token)
+
+    def render_ww_file_span(self, token):
+        return "<a href=\"./files/{target}\">{target}</a>".format(target=token.name)
 
     def render_ww_image_span(self, token):
         return "<img alt='Embedded Image' href='{target}'/>".format(target=token.id)
@@ -94,11 +114,10 @@ def _jinja_filter_name_case(val: str):
 
 def _jinja_filter_md(val: str):
     with WWHTMLRenderer() as renderer:
-        return bleach.clean(
+        return cleaner.clean(
             renderer.render(
                 Document(val)
-            ),
-            tags=allowed_tags,
+            )
         )
 
 


### PR DESCRIPTION
- Reduce whitelist of allowed tags
- Restrict allowed attributes
- Add placeholder support for file links
- Linkify URLs in the transcript (whitelist protocols supported by WW clients)

@brunnjf I'll run this by Olgierd in the morning. I'm also trying to find a simple way to replicate the security checks from the WW link parser (mismatched URLs in link label etc.), but may disable the linkifier if it turns out to be too messy.