### PR TITLE
add meta tag for utf-8 coding

### DIFF
--- a/wwexport/templates/messages.html
+++ b/wwexport/templates/messages.html
@@ -21,6 +21,7 @@
 # SOFTWARE.
 #}<!DOCTYPE html>
 <html lang="en">
+<meta charset="utf-8">
 <head>
     <title>Messages for {{ month_year }}</title>
     <link rel="stylesheet" type="text/css" href="../../{{styles}}" />


### PR DESCRIPTION
This solves the issues with german äöüÄÖÜß and other special characters.