### PR TITLE
add an option to continue on certain graphql errors

### DIFF
--- a/wwexport/__main__.py
+++ b/wwexport/__main__.py
@@ -103,6 +103,8 @@ def main(argv):
 
     parser.add_argument("--annotations", action="store_true", help="Write all annotations in the message files. Even without this option, the content of a generic annotation will be exported if there is no other message content.")
 
+    parser.add_argument("--graphqlerror", type=env.OnError, choices=list(env.OnError), default=env.OnError.exit, help="Determines how certain GraphQL errors are handled. Use with caution as this can cause some errors to be written to the log, but otherwise ignored. Recommended to use this only in conjunction with the spaceid parameter to limit the use to problematic content. This does not affect certain HTML generation and even permission denied errors embedded in GraphQL which which will always continue, regardless of this setting. This setting only affects unexpected errors inside GraphQL responses, allowing the program to continue even when the server returns some errors on particular content.")
+
     logging_group = parser.add_argument_group("logging")
     logging_group.add_argument(
         "--loglevel", type=LogLevel, default=LogLevel.info, choices=list(LogLevel), help="Messages of this type will be printed to a {} file in the export directory. Regardless, errors and warnings are ALWAYS printed to a separate {}.".format(debug_file_name, error_file_name))
@@ -142,6 +144,10 @@ def main(argv):
         logger.addHandler(file_log_handler)
 
     logger.info("wwexport - running build %s", build_info)
+
+    # error handling
+    if args.graphqlerror:
+        env.on_graphql_error = args.graphqlerror
 
     # auth
     auth_token = None
@@ -231,7 +237,7 @@ Exporting to {}""".format(env.export_root))
             "Export incomplete. Aborting with HTTP status code %s and reason %s. If problem persists, run with a debug enabled and check the prior request. You may also run the export space by space.", err.status_code, err.reason)
         error = True
     except queries.GraphQLError:
-        logger.exception("Export incomplete. Terminating with GraphQLError. If problem persists, run with a debug enabled and check the prior request. You may also run the export space by space.")
+        logger.exception("Export incomplete. Terminating with GraphQLError. If problem persists, run with a debug enabled and check the prior request. You may also run the export space by space. Consider using the --graphqlerror CONTINUE option if this persists and you are unable to export content.")
         error = True
     except urllib.error.URLError:
         logger.exception("Export incomplete. Problem with the HTTP Connection. Restart the export and it will resume where you left off (for the most part).")

--- a/wwexport/__main__.py
+++ b/wwexport/__main__.py
@@ -103,7 +103,7 @@ def main(argv):
 
     parser.add_argument("--annotations", action="store_true", help="Write all annotations in the message files. Even without this option, the content of a generic annotation will be exported if there is no other message content.")
 
-    parser.add_argument("--graphqlerror", type=env.OnError, choices=list(env.OnError), default=env.OnError.exit, help="Determines how certain GraphQL errors are handled. Use with caution as this can cause some errors to be written to the log, but otherwise ignored. Recommended to use this only in conjunction with the spaceid parameter to limit the use to problematic content. This does not affect certain HTML generation and even permission denied errors embedded in GraphQL which which will always continue, regardless of this setting. This setting only affects unexpected errors inside GraphQL responses, allowing the program to continue even when the server returns some errors on particular content.")
+    parser.add_argument("--graphqlerror", type=env.OnError, choices=list(env.OnError), default=env.OnError.exit, help="Determines how certain GraphQL errors are handled. Use with caution as this can cause some errors to be written to the log, but otherwise ignored. Recommended to use this only in conjunction with the spaceid parameter to limit the use to problematic content. This does not affect certain HTML generation and even permission denied errors embedded in GraphQL which will always continue, regardless of this setting. This setting only affects unexpected errors inside GraphQL responses, allowing the program to continue even when the server returns some errors on particular content.")
 
     logging_group = parser.add_argument_group("logging")
     logging_group.add_argument(

--- a/wwexport/core.py
+++ b/wwexport/core.py
@@ -204,7 +204,7 @@ def write_message_to_csv(message: str, writer: csv.DictWriter) -> None:
     if message["content"] is None:
         if message["typedAnnotations"] is not None and len(message["typedAnnotations"]) > 0:
             typedAnnotation = message["typedAnnotations"][0]
-            if typedAnnotation["text"] is not None:
+            if typedAnnotation is not None and "text" in typedAnnotation and typedAnnotation["text"] is not None:
                 logger.debug(
                     "Content is empty, but found an annotation with text on message %s", message["id"])
                 message["content"] = typedAnnotation["text"] or " "

--- a/wwexport/env.py
+++ b/wwexport/env.py
@@ -20,10 +20,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from enum import Enum
 from tqdm import tqdm
 from pathlib import Path
 
+
+class OnError(Enum):
+    exit = "EXIT"
+    cont = "CONTINUE"
+
+    def __str__(self):
+        return self.value
+
+
 export_root = Path.home() / "Watson Workspace Export"
+on_graphql_error = OnError.exit
 
 
 def progress_bar(iterable=None, desc=None, position=None, unit="", initial=0):

--- a/wwexport/queries.py
+++ b/wwexport/queries.py
@@ -22,6 +22,7 @@
 
 from wwexport import constants
 from wwexport import auth
+from wwexport import env
 
 import datetime
 import urllib
@@ -86,7 +87,10 @@ class Query:
             if "403" in error_codes:
                 error_codes.remove("403")
             if len(error_codes) > 0:
-                raise GraphQLError(next_level["errors"])
+                if env.on_graphql_error is env.OnError.cont:
+                    logger.error("Set to continue on GraphQL errors, ignoring GraphQL error(s) %s", next_level["errors"])
+                else:
+                    raise GraphQLError(next_level["errors"])
             else:
                 logger.error(
                     "encountered permission denied (403) while fetching data %s", next_level)


### PR DESCRIPTION
Modified command line parameters to allow --graphqlerror CONTINUE as an option. This was found to be particularly useful for some spaces with very old content which was inserted into the conversation before certain content validation was in place. In some cases, this old content can cause GraphQL errors for annotations which do not conform to the annotation schema. Previously, the tool would stop execution on these errors. With the continue option specified, the tool will attempt to continue even in these cases, exporting as much as possible even beyond the message where the error was encountered.