### PR TITLE
Restrict markdown processing to syntax supported by WW

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ name = "pypi"
 
 [packages]
 python-dateutil = "==2.7.5"
-mistletoe = "==0.7.1"
 tqdm = "==4.29.0"
 bleach = "==3.0.2"
 altgraph = "==0.16.1"
@@ -22,6 +21,7 @@ webencodings = "==0.5.1"
 Babel = "==2.6.0"
 MarkupSafe = "==1.1.0"
 PyInstaller = "==3.4"
+markdown = "==3.0.1"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "45c9c5373e014d610c6ad3e2fd85c2c45995c941fad07dc7b18141e8255bef37"
+            "sha256": "aed0770e9659a22969885a6e151f00985319e0b11f8331e6b840abc0fcae57a2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -79,6 +79,14 @@
             "index": "pypi",
             "version": "==1.11"
         },
+        "markdown": {
+            "hashes": [
+                "sha256:c00429bd503a47ec88d5e30a751e147dcb4c6889663cd3e2ba0afe858e009baa",
+                "sha256:d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c"
+            ],
+            "index": "pypi",
+            "version": "==3.0.1"
+        },
         "markupsafe": {
             "hashes": [
                 "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
@@ -112,13 +120,6 @@
             ],
             "index": "pypi",
             "version": "==1.1.0"
-        },
-        "mistletoe": {
-            "hashes": [
-                "sha256:5e6cc5879dc835f3ae633e4c649a045fd6d4620d0b43044cfeaae35b1b1c707c"
-            ],
-            "index": "pypi",
-            "version": "==0.7.1"
         },
         "pefile": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ future==0.17.1
 idna==2.8
 Jinja2==2.10
 macholib==1.11
+markdown==3.0.1
 MarkupSafe==1.1.0
-mistletoe==0.7.1
 pefile==2018.8.8
 PyInstaller==3.4
 python-dateutil==2.7.5

--- a/wwexport/resources/styles.css
+++ b/wwexport/resources/styles.css
@@ -29,6 +29,10 @@ img {
   margin: 0;
 }
 
+.ic-message-container p:not(:last-child) {
+  margin-bottom: 16px;
+}
+
 .ic-transcript-item {
   color: rgb(29, 54, 73);
   line-height: 24px;

--- a/wwexport/templates/messages.html
+++ b/wwexport/templates/messages.html
@@ -44,9 +44,9 @@
           <div class="ic-annotation-border" style="background-color: {{ message.annotationColor }}"></div>
           {% endif %}
           <div class="ic-annotation-content">
-            {% if message.annotationTitle is string %}
+            {% if message.annotationTitle %}
             <div class="ic-annotation-actor">
-              {% if message.annotationActor is string %}
+              {% if message.annotationActor %}
               <span class="ic-annotation-actor-name">{{ message.annotationActor }}</span>
               {% endif %}
               <span class="ic-annotation-title">{{ message.annotationTitle }}</span>

--- a/wwexport/templates/messages.html
+++ b/wwexport/templates/messages.html
@@ -53,7 +53,7 @@
             </div>
             {% endif %}
             <div class="ic-message-container">
-              {{ message["content"] | md }}
+              {{ message["content"] | md | safe }}
             </div>
           </div>
         </div>

--- a/wwexport/templates/messages.html
+++ b/wwexport/templates/messages.html
@@ -53,7 +53,7 @@
             </div>
             {% endif %}
             <div class="ic-message-container">
-              {{ message["content"] | md | safe }}
+              {{ message["content"] | md }}
             </div>
           </div>
         </div>

--- a/wwexport/templates/messages.html
+++ b/wwexport/templates/messages.html
@@ -23,7 +23,7 @@
 <html lang="en">
 <meta charset="utf-8">
 <head>
-    <title>Messages for {{ month_year }}</title>
+    <title>Messages for {{ source_file }}</title>
     <link rel="stylesheet" type="text/css" href="../../{{styles}}" />
 </head>
 <body>

--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -84,7 +84,7 @@ class FilePattern(InlineProcessor):
             el.set("href", paths[m.group(1)])
         else:
             el.set("href", "")
-            logger.error("Could not resolve link in message to file for file %s", match.group(1))
+            logger.error("Could not resolve link in message to file for file %s", m.group(1))
         return el, m.start(0), m.end(0)
 
 class ImagePattern(InlineProcessor):
@@ -98,7 +98,7 @@ class ImagePattern(InlineProcessor):
             el.set("src", paths[m.group(1)])
         else:
             el.set("src", "")
-            logger.error("Could not resolve link in message to image for image %s", match.group(1))
+            logger.error("Could not resolve link in message to image for image %s", m.group(1))
         return el, m.start(0), m.end(0)
 
 class WWExtension(Extension):

--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -30,7 +30,6 @@ import dateutil.parser
 import json
 import logging
 import markdown
-import re
 import sys
 from pathlib import Path
 from functools import partial
@@ -136,7 +135,7 @@ class WWExtension(Extension):
         del md.parser.blockprocessors["ulist"]
 
 
-markdownRenderer = markdown.Markdown(extensions=[WWExtension(), "fenced_code", "nl2br"], output_format="html5")
+markdownRenderer = markdown.Markdown(extensions=[WWExtension(), "markdown.extensions.fenced_code", "markdown.extensions.nl2br"], output_format="html5")
 
 def _jinja_filter_md(val: str):
     content = None

--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -82,7 +82,7 @@ class FilePattern(InlineProcessor):
         el.text = m.group(3)
         el.set("class", "ic-file")
         if m.group(1) in paths:
-            el.set("href", paths[m.group(1)])
+            el.set("href", "file://" + paths[m.group(1)])
         else:
             el.set("href", "")
             logger.error("Could not resolve link in message to file for file %s", m.group(1))
@@ -96,7 +96,7 @@ class ImagePattern(InlineProcessor):
         # el.set("width", m.group(4))
         # el.set("height", m.group(5))
         if m.group(1) in paths:
-            el.set("src", paths[m.group(1)])
+            el.set("src", "file://" + paths[m.group(1)])
         else:
             el.set("src", "")
             logger.error("Could not resolve link in message to image for image %s", m.group(1))

--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -52,12 +52,6 @@ logger = logging.getLogger("wwexport")
 paths = {}
 
 cleaner = Cleaner(
-    tags=[],
-    strip=False,
-    strip_comments=True
-)
-
-linkifier = Cleaner(
     tags=["a", "br", "code", "em", "img", "p", "pre", "span", "strong"],
     attributes={"a": ["class", "href", "rel"], "img": ["alt", "src"]},
     styles=[],
@@ -151,11 +145,9 @@ def _jinja_filter_md(val: str):
     try:
         # protect WW markdown
         content = CUSTOM_TAG_RE.sub(r"%%WWPLACEHOLDER%%\2%%/WWPLACEHOLDER%%", val)
-        # remove ALL markup
-        content = cleaner.clean(content)
         content = markdownRenderer.reset().convert(content)
-        # ensure only expected tags are output, convert bare URLs to links
-        content = linkifier.clean(content)
+        # ensure only expected tags are output, convert bare URLs (with allowed protocols) to links
+        content = cleaner.clean(content)
     except NameError:
         logger.exception("Problem with markdown conversion - using message as plaintext for some message content")
         content = val

--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -29,6 +29,7 @@ import dateutil
 import dateutil.parser
 import json
 import logging
+import markdown
 import re
 import sys
 from pathlib import Path
@@ -36,118 +37,133 @@ from functools import partial
 
 from bleach.sanitizer import Cleaner
 from bleach.linkifier import LinkifyFilter
-from mistletoe import Document, html_renderer
-from mistletoe.span_token import SpanToken
 from babel.dates import format_date, format_datetime, format_time
 # force pyinstaller to find babel.numbers and include it
 import babel.numbers
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+from markdown.extensions import Extension
+from markdown.inlinepatterns import InlineProcessor
+from markdown.inlinepatterns import SimpleTagPattern
+from markdown.postprocessors import Postprocessor
+from markdown.util import etree
 
 logger = logging.getLogger("wwexport")
 paths = {}
+
 cleaner = Cleaner(
-    tags=['a', 'code', 'em', 'img', 'p', 'pre', 'span', 'strong'],
-    attributes={'a': ['class', 'href', 'rel'], 'img': ['src']},
-    styles=[],
-    protocols=['file', 'ftp', 'ftps', 'git', 'http', 'https', 'ibmscp', 'ldap', 'ldaps', 'mailto', 'notes', 'tel', 'watsonworkspace'],
+    tags=[],
     strip=False,
-    strip_comments=True,
-    filters=[partial(LinkifyFilter, skip_tags=['code', 'pre'])]
+    strip_comments=True
 )
 
-class WWMentionSpan(SpanToken):
-    pattern = re.compile(r"\<\@(.+?)\|(.+?)\>")
-
-    def __init__(self, match):
-        self.parse_inner = False
-        self.id = match.group(1)
-        self.display = match.group(2)
-
-class WWSpaceMentionSpan(SpanToken):
-    pattern = re.compile(r"\<(\@space)\>")
-
-    def __init__(self, match):
-        self.parse_inner = False
-        self.display = match.group(1)
-
-class WWFileSpan(SpanToken):
-    pattern = re.compile(r"\<\$file\|(.*?)(\|(.*?))?\>")
-
-    def __init__(self, match):
-        global paths
-        self.parse_inner = False
-        if match.group(1) in paths:
-            self.path = paths[match.group(1)]
-        else:
-            self.path = ""
-            logger.error("Could not resolve link in message to file for file %s", match.group(1))
-        self.name = match.group(3)
-
-class WWImageSpan(SpanToken):
-    pattern = re.compile(r"\<\$image\|(.*?)(\|(([0-9])+x([0-9])+))?\>")
-
-    def __init__(self, match):
-        global paths
-        self.parse_inner = False
-        if match.group(1) in paths:
-            self.path = paths[match.group(1)]
-        else:
-            self.path = ""
-            logger.error("Could not resolve link in message to image for image %s", match.group(1))
-        self.width = match.group(4)
-        self.height = match.group(5)
-
-class WWBoldSpan(SpanToken):
-    pattern = re.compile(r"\*([^*]+)\*")
-
-    def __init__(self, match):
-        self.target = match.group(1)
-
-class WWHTMLRenderer(html_renderer.HTMLRenderer):
-    def __init__(self):
-        super().__init__(WWMentionSpan, WWSpaceMentionSpan, WWFileSpan, WWImageSpan, WWBoldSpan)
-
-    def render_ww_mention_span(self, token):
-        return "<strong>{name}</strong>".format(name=token.display)
-
-    def render_ww_space_mention_span(self, token):
-        return self.render_ww_mention_span(token)
-
-    def render_ww_file_span(self, token):
-        return "<a class=\"ic-file\" href=\"{path}\">{name}</a>".format(name=token.name, path=token.path)
-
-    def render_ww_image_span(self, token):
-        return "<img src=\"{path}\" alt />".format(path=token.path)
-
-    def render_ww_bold_span(self, token):
-        return "<strong>{inner}</strong>".format(inner=self.render_inner(token))
-
+linkifier = Cleaner(
+    tags=["a", "br", "code", "em", "img", "p", "pre", "span", "strong"],
+    attributes={"a": ["class", "href", "rel"], "img": ["alt", "src"]},
+    styles=[],
+    protocols=["file", "ftp", "ftps", "git", "http", "https", "ibmscp", "ldap", "ldaps", "mailto", "notes", "tel", "watsonworkspace"],
+    strip=False,
+    strip_comments=True,
+    filters=[partial(LinkifyFilter, skip_tags=["code", "pre"])]
+)
 
 jinja_env = Environment(
     # use of the FileSystemLoader is required for PyInstaller packaging
-    loader=FileSystemLoader(searchpath=str(Path(__file__).parent / "templates")),
-    autoescape=select_autoescape(['html', 'xml'])
+    loader=FileSystemLoader(searchpath=str(Path(__file__).parent / "templates"))
 )
 
 
 def _jinja_filter_name_case(val: str):
     return val.title() if val is not None and (val.islower() or val.isupper()) else val
 
+CUSTOM_TAG_RE = re.compile(r"(<)((\@|\$file|\$image)(.+?))(>)")
+FILE_RE = r"%%WWPLACEHOLDER%%\$file\|(.*?)(\|(.*?))?%%/WWPLACEHOLDER%%"
+IMAGE_RE = r"%%WWPLACEHOLDER%%\$image\|(.*?)(\|(([0-9]+)x([0-9]+)))?%%/WWPLACEHOLDER%%"
+MENTION_RE = r"%%WWPLACEHOLDER%%@(.+?)\|(.+?)%%/WWPLACEHOLDER%%"
+SPACE_MENTION_RE = r"(%%WWPLACEHOLDER%%)(@space)%%/WWPLACEHOLDER%%"
+STRONG_RE = r"(\*)(.+?)\*"
+
+class FilePattern(InlineProcessor):
+    def handleMatch(self, m, data):
+        global paths
+        el = etree.Element("a")
+        el.text = m.group(3)
+        el.set("class", "ic-file")
+        if m.group(1) in paths:
+            el.set("href", paths[m.group(1)])
+        else:
+            el.set("href", "")
+            logger.error("Could not resolve link in message to file for file %s", match.group(1))
+        return el, m.start(0), m.end(0)
+
+class ImagePattern(InlineProcessor):
+    def handleMatch(self, m, data):
+        global paths
+        el = etree.Element("img")
+        el.set("alt", "")
+        # el.set("width", m.group(4))
+        # el.set("height", m.group(5))
+        if m.group(1) in paths:
+            el.set("src", paths[m.group(1)])
+        else:
+            el.set("src", "")
+            logger.error("Could not resolve link in message to image for image %s", match.group(1))
+        return el, m.start(0), m.end(0)
+
+class WWExtension(Extension):
+    def extendMarkdown(self, md, md_globals):
+        md.registerExtension(self)
+        md.inlinePatterns["strong"] = SimpleTagPattern(STRONG_RE, "strong")
+
+        md.inlinePatterns.add("file", FilePattern(FILE_RE), ">emphasis2")
+        md.inlinePatterns.add("image", ImagePattern(IMAGE_RE), ">emphasis2")
+        md.inlinePatterns.add("mention", SimpleTagPattern(MENTION_RE, "strong"), ">emphasis2")
+        md.inlinePatterns.add("space_mention", SimpleTagPattern(SPACE_MENTION_RE, "strong"), ">emphasis2")
+
+        del md.preprocessors["html_block"]
+        del md.preprocessors["reference"]
+
+        del md.inlinePatterns["autolink"]
+        del md.inlinePatterns["automail"]
+        del md.inlinePatterns["em_strong"]
+        del md.inlinePatterns["entity"]
+        del md.inlinePatterns["html"]
+        del md.inlinePatterns["image_link"]
+        del md.inlinePatterns["image_reference"]
+        del md.inlinePatterns["reference"]
+        del md.inlinePatterns["short_reference"]
+        del md.inlinePatterns["strong_em"]
+
+        del md.parser.blockprocessors["code"] # `code` is an indented code block, WW only supports 'fenced' code blocks (using ```\nbackticks\n```)
+        del md.parser.blockprocessors["hashheader"]
+        del md.parser.blockprocessors["hr"]
+        del md.parser.blockprocessors["indent"]
+        del md.parser.blockprocessors["olist"]
+        del md.parser.blockprocessors["quote"]
+        del md.parser.blockprocessors["setextheader"]
+        del md.parser.blockprocessors["ulist"]
+
+
+markdownRenderer = markdown.Markdown(extensions=[WWExtension(), "fenced_code", "nl2br"], output_format="html5")
 
 def _jinja_filter_md(val: str):
-    with WWHTMLRenderer() as renderer:
-        content = None
-        try:
-            content = renderer.render(Document(val))
-        except NameError:
-            logger.exception("Problem with markdown conversion - using message as plaintext for some message content")
-            content = val
-        except ValueError:
-            logger.exception("Problem with markdown conversion - using message as plaintext for some message content")
-            content = val
+    content = None
+    try:
+        # protect WW markdown
+        content = CUSTOM_TAG_RE.sub(r"%%WWPLACEHOLDER%%\2%%/WWPLACEHOLDER%%", val)
+        # remove ALL markup
+        content = cleaner.clean(content)
+        content = markdownRenderer.reset().convert(content)
+        # ensure only expected tags are output, convert bare URLs to links
+        content = linkifier.clean(content)
+    except NameError:
+        logger.exception("Problem with markdown conversion - using message as plaintext for some message content")
+        content = val
+    except ValueError:
+        logger.exception("Problem with markdown conversion - using message as plaintext for some message content")
+        content = val
 
-        return cleaner.clean(content)
+    return content
 
 
 jinja_env.filters["format_date"] = format_date

--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -45,7 +45,6 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from markdown.extensions import Extension
 from markdown.inlinepatterns import InlineProcessor
 from markdown.inlinepatterns import SimpleTagPattern
-from markdown.postprocessors import Postprocessor
 from markdown.util import etree
 
 logger = logging.getLogger("wwexport")

--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -41,7 +41,7 @@ from babel.dates import format_date, format_datetime, format_time
 # force pyinstaller to find babel.numbers and include it
 import babel.numbers
 
-from jinja2 import Environment, FileSystemLoader, select_autoescape
+from jinja2 import Environment, FileSystemLoader
 from markdown.extensions import Extension
 from markdown.inlinepatterns import InlineProcessor
 from markdown.inlinepatterns import SimpleTagPattern
@@ -69,11 +69,10 @@ jinja_env = Environment(
 def _jinja_filter_name_case(val: str):
     return val.title() if val is not None and (val.islower() or val.isupper()) else val
 
-CUSTOM_TAG_RE = re.compile(r"(<)((\@|\$file|\$image)(.+?))(>)")
-FILE_RE = r"%%WWPLACEHOLDER%%\$file\|(.*?)(\|(.*?))?%%/WWPLACEHOLDER%%"
-IMAGE_RE = r"%%WWPLACEHOLDER%%\$image\|(.*?)(\|(([0-9]+)x([0-9]+)))?%%/WWPLACEHOLDER%%"
-MENTION_RE = r"%%WWPLACEHOLDER%%@(.+?)\|(.+?)%%/WWPLACEHOLDER%%"
-SPACE_MENTION_RE = r"(%%WWPLACEHOLDER%%)(@space)%%/WWPLACEHOLDER%%"
+FILE_RE = r"<\$file\|(.*?)(\|(.*?))?>"
+IMAGE_RE = r"<\$image\|(.*?)(\|(([0-9]+)x([0-9]+)))?>"
+MENTION_RE = r"<@(.+?)\|(.+?)>"
+SPACE_MENTION_RE = r"(<)(@space)>"
 STRONG_RE = r"(\*)(.+?)\*"
 
 class FilePattern(InlineProcessor):
@@ -142,9 +141,7 @@ markdownRenderer = markdown.Markdown(extensions=[WWExtension(), "fenced_code", "
 def _jinja_filter_md(val: str):
     content = None
     try:
-        # protect WW markdown
-        content = CUSTOM_TAG_RE.sub(r"%%WWPLACEHOLDER%%\2%%/WWPLACEHOLDER%%", val)
-        content = markdownRenderer.reset().convert(content)
+        content = markdownRenderer.reset().convert(val)
         # ensure only expected tags are output, convert bare URLs (with allowed protocols) to links
         content = cleaner.clean(content)
     except NameError:

--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -40,7 +40,7 @@ from babel.dates import format_date, format_datetime, format_time
 # force pyinstaller to find babel.numbers and include it
 import babel.numbers
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from markdown.extensions import Extension
 from markdown.inlinepatterns import InlineProcessor
 from markdown.inlinepatterns import SimpleTagPattern
@@ -51,7 +51,7 @@ paths = {}
 
 cleaner = Cleaner(
     tags=["a", "br", "code", "em", "img", "p", "pre", "span", "strong"],
-    attributes={"a": ["class", "href", "rel"], "img": ["alt", "src"]},
+    attributes={"a": ["class", "href", "rel"], "code": ["class"], "img": ["alt", "src"]},
     styles=[],
     protocols=["file", "ftp", "ftps", "git", "http", "https", "ibmscp", "ldap", "ldaps", "mailto", "notes", "tel", "watsonworkspace"],
     strip=False,
@@ -61,7 +61,8 @@ cleaner = Cleaner(
 
 jinja_env = Environment(
     # use of the FileSystemLoader is required for PyInstaller packaging
-    loader=FileSystemLoader(searchpath=str(Path(__file__).parent / "templates"))
+    loader=FileSystemLoader(searchpath=str(Path(__file__).parent / "templates")),
+    autoescape=select_autoescape(['html', 'xml'])
 )
 
 

--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -179,7 +179,7 @@ def csv_to_html(file: Path, styles: str = "styles.css"):
         html_file.write(
             template.render(
                 reader=reader,
-                month_year="201811",
+                source_file=file.name,
                 export_date=datetime.datetime.now(),
                 styles=styles,
             )


### PR DESCRIPTION
- drop mistletoe as disabling tokens is not supported
- adopt Python-Markdown
  - fully configurable / pluggable
  - performance reasonably close to mistletoe
- overhaul the md / HTML processing
  1. ~~escape **all** content~~ (disabled until I find fix for code blocks, see below)
  2. parse md (only WW-supported syntax)
  3. linkify URLs and ensure md parsing didn't produce unexpected tags

This approach ensures that unsupported markdown is preserved as text, as in the WW clients.
For example:
```
- one
- two
- three
```
will be preserved as-is, instead of being converted to the broken:
```
<ul><li>one</li>...
```

**Remaining issues:** (workaround in this PR for now, will follow up with proper fix in separate PR)
- [ ] markup in inline code
  ![image](https://user-images.githubusercontent.com/2829095/51606694-856a9700-1f0a-11e9-894c-55bc1a513caf.png)
- [ ] markup in code blocks
  ![image](https://user-images.githubusercontent.com/2829095/51606797-cfec1380-1f0a-11e9-8bc8-abc07c49839a.png)
