### PR TITLE
remove titles from html files

### DIFF
--- a/wwexport/templates/messages.html
+++ b/wwexport/templates/messages.html
@@ -23,7 +23,6 @@
 <html lang="en">
 <meta charset="utf-8">
 <head>
-    <title>Messages for {{ source_file }}</title>
     <link rel="stylesheet" type="text/css" href="../../{{styles}}" />
 </head>
 <body>

--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -179,7 +179,6 @@ def csv_to_html(file: Path, styles: str = "styles.css"):
         html_file.write(
             template.render(
                 reader=reader,
-                source_file=file.name,
                 export_date=datetime.datetime.now(),
                 styles=styles,
             )


### PR DESCRIPTION
Just a minor thing, but the fix to correct the titles of HTML files made them a bit odd - "Messages for 2019.1 messages.csv" for instance. The normal handling of most browsers, using the file name as the title, works well now given the current file names.