### PR TITLE
fix range on resume check, avoid double messages in html

### DIFF
--- a/wwexport/core.py
+++ b/wwexport/core.py
@@ -237,8 +237,8 @@ def get_messages_path(space_export_root: str, year: int, month: int) -> str:
 
 
 def find_messages_resume_point(space_export_root) -> ResumePoint:
-    for year in range(datetime.datetime.now().year, 2014, -1):
-        for month in range(12, 1, -1):
+    for year in range(datetime.datetime.now().year, 2013, -1):
+        for month in range(12, 0, -1):
             path = get_messages_path(space_export_root, year, month)
             if path.exists():
                 logger.debug("Found possible resume point in %s", path)
@@ -326,6 +326,8 @@ def export_space(space: dict, auth_token: str, export_root_folder: PurePath, fil
         logger.info("Resuming from message ID %s at %sms",
                     last_known_id, next_page_time_in_milliseconds)
         previous_page_ids.add(last_known_id)
+    else:
+        logger.info("Resume point not found")
 
     if file_options != FileOptions.none:
         files_folder_path = space_export_root / "files"

--- a/wwexport/templates/messages.html
+++ b/wwexport/templates/messages.html
@@ -28,13 +28,16 @@
 </head>
 <body>
     <div class="ww-export-header">All message times are in UTC.</div>
-    {% set ns = namespace(last_message_created_date=None, message_created=None) %}
+    {% set ns = namespace(last_message_created_date=None, message_created=None, message_ids = []) %}
     {% for message in reader %}
-      {% set ns.message_created = message["created date"] | parse_datetime %}
-      {% if ns.last_message_created_date == None or ns.message_created.date() != ns.last_message_created_date %}
+      {% if message["message id"] not in ns.message_ids %}
+          {% do ns.message_ids.append(message["message id"]) %}
+          {% set ns.message_created = message["created date"] | parse_datetime %}
+          {% if ns.last_message_created_date == None or ns.message_created.date() != ns.last_message_created_date %}
       <div class="ic-message-date" title="{{ ns.message_created|format_date }}" >{{ ns.message_created|format_date(format="full") }}</div>
-      {% endif %}
-      <div class="ic-transcript-item">
+          {% endif %}
+
+      <div class="ic-transcript-item" id="{{ message["message id"] }}">
         <div class="ic-message-meta">
           <span class="ic-person">{{ message["author name"]|name_case }}</span>
           <span class="ic-timestamp">{{ ns.message_created|format_datetime }}</span>
@@ -58,6 +61,7 @@
           </div>
         </div>
       </div>
+      {% endif %}
     {% set ns.last_message_created_date = ns.message_created.date() %}
     {% endfor %}
 </body>

--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -62,7 +62,10 @@ cleaner = Cleaner(
 jinja_env = Environment(
     # use of the FileSystemLoader is required for PyInstaller packaging
     loader=FileSystemLoader(searchpath=str(Path(__file__).parent / "templates")),
-    autoescape=select_autoescape(['html', 'xml'])
+    autoescape=select_autoescape(['html', 'xml']),
+    extensions=["jinja2.ext.do"],
+    trim_blocks=True,
+    lstrip_blocks=True,
 )
 
 


### PR DESCRIPTION
- range should have been to 0 on the month when checking for resume - as it was, January files are not checked when resuming, which means that the program writes all january messages out multiple times IF the resume point would have been in January.
- added a check to the HTML generation to make sure it doesn't print the same message twice. This seemed safer than trying to fix up any "broken" CSVs that might be out in the wild already due to this bug.
- changed jinja config to remove unnecessary whitespace as well