### PR TITLE
use last segment of file ID for match

### DIFF
--- a/wwexport/ww_html.py
+++ b/wwexport/ww_html.py
@@ -99,7 +99,6 @@ def file_path_for_id(id):
 
 class FilePattern(InlineProcessor):
     def handleMatch(self, m, data):
-        global paths
         el = etree.Element("a")
         el.text = m.group(3)
         el.set("class", "ic-file")
@@ -108,7 +107,6 @@ class FilePattern(InlineProcessor):
 
 class ImagePattern(InlineProcessor):
     def handleMatch(self, m, data):
-        global paths
         el = etree.Element("img")
         el.set("alt", "")
         # el.set("width", m.group(4))


### PR DESCRIPTION
Some very old files have links with an ID such as this in the MD:
s3@default@57177d7d9932fed8d0ed573f@file-8364cc06-e3d0-42d1-9629-b3026bd497b2
Whereas the ID of the file as reported by the file service is:
ibm0@default@57177d7d9932fed8d0ed573f@file-8364cc06-e3d0-42d1-9629-b3026bd497b2
(differing by the prefix here)

This results in errors such as:
2019-01-25 08:23:40,076 wwexport ERROR   : Could not resolve link in message to image for image s3@default@57177d7d9932fed8d0ed573f@file-199bbe25-0128-49c3-8cf1-7cd5c4ee7108
since the html generation attempts to look up the file path by it's ID with an exact match.

This change will address that by building the ID to path map only off the last portion of the ID (after the last @ symbol), and then only using the last portion when mapping. Within a space, this is totally fine, although the last portion is actually globally unique anyway.